### PR TITLE
Read permission fix (#175)

### DIFF
--- a/app/src/main/java/co/smartreceipts/android/activities/SmartReceiptsActivity.java
+++ b/app/src/main/java/co/smartreceipts/android/activities/SmartReceiptsActivity.java
@@ -2,6 +2,7 @@ package co.smartreceipts.android.activities;
 
 import android.content.Intent;
 import android.net.Uri;
+import android.os.Build;
 import android.os.Bundle;
 import android.view.Menu;
 import android.view.MenuItem;
@@ -21,6 +22,7 @@ import co.smartreceipts.android.analytics.events.DataPoint;
 import co.smartreceipts.android.analytics.events.DefaultDataPointEvent;
 import co.smartreceipts.android.analytics.events.Events;
 import co.smartreceipts.android.config.ConfigurationManager;
+import co.smartreceipts.android.fragments.PermissionAlertDialogFragment;
 import co.smartreceipts.android.imports.intents.model.FileType;
 import co.smartreceipts.android.imports.intents.widget.IntentImportProvider;
 import co.smartreceipts.android.imports.intents.widget.info.IntentImportInformationPresenter;
@@ -283,7 +285,12 @@ public class SmartReceiptsActivity extends AppCompatActivity implements HasAndro
 
     @Override
     public void presentIntentImportFatalError() {
-        Toast.makeText(this, R.string.toast_attachment_error, Toast.LENGTH_SHORT).show();
-        finish();
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) {
+            navigationHandler.showDialog(PermissionAlertDialogFragment.newInstance(this));
+        } else {
+            Toast.makeText(this, R.string.toast_attachment_error, Toast.LENGTH_SHORT).show();
+            finish();
+        }
     }
+
 }

--- a/app/src/main/java/co/smartreceipts/android/fragments/PermissionAlertDialogFragment.java
+++ b/app/src/main/java/co/smartreceipts/android/fragments/PermissionAlertDialogFragment.java
@@ -1,0 +1,63 @@
+package co.smartreceipts.android.fragments;
+
+import android.Manifest;
+import android.annotation.SuppressLint;
+import android.app.AlertDialog;
+import android.app.Dialog;
+import android.content.Intent;
+import android.net.Uri;
+import android.os.Build;
+import android.os.Bundle;
+import android.provider.Settings;
+
+import androidx.annotation.NonNull;
+import androidx.annotation.RequiresApi;
+import androidx.appcompat.app.AppCompatActivity;
+import androidx.fragment.app.DialogFragment;
+
+import co.smartreceipts.android.R;
+
+/**
+ * Dialog Fragment which asks if user wants to leave feedback
+ */
+public class PermissionAlertDialogFragment extends DialogFragment {
+
+    @RequiresApi(api = Build.VERSION_CODES.M)
+    @NonNull
+    public static PermissionAlertDialogFragment newInstance(@NonNull AppCompatActivity activity) {
+        final PermissionAlertDialogFragment permissionDialogFragment = new PermissionAlertDialogFragment();
+        final Bundle args = new Bundle();
+        args.putBoolean("shouldShowRationale", activity.shouldShowRequestPermissionRationale(Manifest.permission.READ_EXTERNAL_STORAGE));
+        permissionDialogFragment.setArguments(args);
+        return permissionDialogFragment;
+    }
+
+    @NonNull
+    @Override
+    public Dialog onCreateDialog(Bundle savedInstanceState) {
+        AlertDialog.Builder builder = new AlertDialog.Builder(getContext())
+                .setCancelable(false)
+                .setTitle(getString(R.string.storage_permission_required));
+
+        if (getArguments().getBoolean("shouldShowRationale")) {
+            builder.setIcon(R.mipmap.ic_launcher)
+                    .setMessage(getString(R.string.permission_must_be_granted))
+                    .setPositiveButton(getString(R.string.ok), null);
+        } else {
+            builder.setIcon(R.drawable.ic_error_outline_24dp)
+                    .setMessage(getString(R.string.approve_permission))
+                    .setNegativeButton(getString(R.string.no), null)
+                    .setPositiveButton(getString(R.string.yes), (dialogInterface, i) -> {
+                        final Intent intent = new Intent();
+                        intent.setAction(Settings.ACTION_APPLICATION_DETAILS_SETTINGS);
+                        intent.addCategory(Intent.CATEGORY_DEFAULT);
+                        intent.setData(Uri.parse("package:" + getContext().getPackageName()));
+                        intent.addFlags(Intent.FLAG_ACTIVITY_NEW_TASK);
+                        intent.addFlags(Intent.FLAG_ACTIVITY_NO_HISTORY);
+                        intent.addFlags(Intent.FLAG_ACTIVITY_EXCLUDE_FROM_RECENTS);
+                        getContext().startActivity(intent);
+                    });
+        }
+        return builder.create();
+    }
+}

--- a/app/src/main/java/co/smartreceipts/android/imports/intents/IntentImportProcessor.java
+++ b/app/src/main/java/co/smartreceipts/android/imports/intents/IntentImportProcessor.java
@@ -35,7 +35,7 @@ import io.reactivex.subjects.Subject;
 public class IntentImportProcessor {
 
     private static final String INTENT_CONSUMED = "co.smartreceipts.android.INTENT_CONSUMED";
-    private static final Set<String> SUPPORTED_SMR_MIME_TYPES = new HashSet<>(Arrays.asList("application/octet-stream", "application/zip"));
+    private static final Set<String> SUPPORTED_SMR_MIME_TYPES = new HashSet<>(Arrays.asList("application/octet-stream", "application/zip", "application/x-zip"));
 
     private final Context context;
     private final Analytics analytics;

--- a/app/src/main/java/co/smartreceipts/android/imports/intents/widget/info/IntentImportInformationInteractor.java
+++ b/app/src/main/java/co/smartreceipts/android/imports/intents/widget/info/IntentImportInformationInteractor.java
@@ -71,9 +71,7 @@ public class IntentImportInformationInteractor {
                                     });
                         }
                     })
-                    .doOnSuccess(ignored -> {
-                        intent.putExtra(INTENT_INFORMATION_SHOW, true);
-                    })
+                    .doOnSuccess(ignored -> intent.putExtra(INTENT_INFORMATION_SHOW, true))
                     .toObservable()
                     .map(UiIndicator::success)
                     .startWith(UiIndicator.idle());

--- a/app/src/main/java/co/smartreceipts/android/sync/widget/backups/BackupsFragment.java
+++ b/app/src/main/java/co/smartreceipts/android/sync/widget/backups/BackupsFragment.java
@@ -1,7 +1,6 @@
 package co.smartreceipts.android.sync.widget.backups;
 
 import android.annotation.SuppressLint;
-import android.app.Activity;
 import android.content.Context;
 import android.content.Intent;
 import android.os.Bundle;
@@ -11,6 +10,7 @@ import androidx.appcompat.app.ActionBar;
 import androidx.appcompat.app.AppCompatActivity;
 import androidx.recyclerview.widget.RecyclerView;
 import androidx.appcompat.widget.Toolbar;
+
 import android.view.LayoutInflater;
 import android.view.Menu;
 import android.view.MenuInflater;
@@ -28,6 +28,7 @@ import co.smartreceipts.android.R;
 import co.smartreceipts.android.activities.NavigationHandler;
 import co.smartreceipts.android.fragments.SelectAutomaticBackupProviderDialogFragment;
 import co.smartreceipts.android.fragments.WBFragment;
+import co.smartreceipts.android.imports.intents.widget.info.IntentImportInformationPresenter;
 import co.smartreceipts.android.persistence.PersistenceManager;
 import co.smartreceipts.android.purchases.PurchaseManager;
 import co.smartreceipts.android.purchases.model.InAppPurchase;
@@ -59,6 +60,8 @@ public class BackupsFragment extends WBFragment implements BackupProviderChangeL
     PurchaseManager purchaseManager;
     @Inject
     NavigationHandler navigationHandler;
+    @Inject
+    IntentImportInformationPresenter intentImportInformationPresenter;
 
     private RemoteBackupsDataCache remoteBackupsDataCache;
     private CompositeDisposable compositeDisposable;
@@ -172,13 +175,18 @@ public class BackupsFragment extends WBFragment implements BackupProviderChangeL
     @Override
     public void onActivityResult(int requestCode, int resultCode, @Nullable Intent data) {
         super.onActivityResult(requestCode, resultCode, data);
-        if (resultCode == Activity.RESULT_OK) {
-            if (requestCode == IMPORT_SMR_REQUEST_CODE) {
-                if (data != null) {
-                    navigationHandler.showDialog(ImportLocalBackupDialogFragment.newInstance(data.getData()));
-                }
-            }
+        if (data != null) {
+            data.setAction(Intent.ACTION_VIEW);
+            getActivity().setIntent(data);
+            intentImportInformationPresenter.subscribe();
         }
+    }
+
+    @Override
+    public void onDestroy() {
+        Logger.info(this, "onDestroy");
+        intentImportInformationPresenter.unsubscribe();
+        super.onDestroy();
     }
 
     @Override

--- a/app/src/main/java/co/smartreceipts/android/sync/widget/backups/ImportLocalBackupDialogFragment.java
+++ b/app/src/main/java/co/smartreceipts/android/sync/widget/backups/ImportLocalBackupDialogFragment.java
@@ -57,7 +57,7 @@ public class ImportLocalBackupDialogFragment extends DialogFragment implements D
     @Override
     public Dialog onCreateDialog(Bundle savedInstanceState) {
         final View dialogView = getActivity().getLayoutInflater().inflate(R.layout.dialog_import_backup, null);
-        mOverwriteCheckBox = (CheckBox) dialogView.findViewById(R.id.dialog_import_overwrite);
+        mOverwriteCheckBox = dialogView.findViewById(R.id.dialog_import_overwrite);
 
         final AlertDialog.Builder builder = new AlertDialog.Builder(getContext());
         builder.setView(dialogView);

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -274,6 +274,10 @@
     <string name="dialog_import_positive">Importieren</string>
     <string name="dialog_import_text">Überschreiben Sie alle vorhandenen Daten</string>
     <string name="dialog_export_working">Export Ihrer Belege …</string>
+    <string name="storage_permission_required">Opslagrechten vereist</string>
+    <string name="permission_must_be_granted">Er moet opslagmachtiging worden verleend om dit back-upbestand te importeren.</string>
+    <string name="approve_permission">Het importeren van dit back-upbestand kan niet worden gedaan omdat de opslagmachtiging is geweigerd. Wilt u het goedkeuren in de app-instellingen?</string>
+    <string name="ok">OK</string>
 
     <!-- ===================== backup menu ======================== -->
     <string name="backups">Backups</string>

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -274,6 +274,10 @@
     <string name="dialog_import_positive">Importar</string>
     <string name="dialog_import_text">Sobrescribir todos los datos existentes</string>
     <string name="dialog_export_working">Exportando tus recibos…</string>
+    <string name="storage_permission_required">Permiso de almacenamiento requerido</string>
+    <string name="permission_must_be_granted">Se debe otorgar permiso de almacenamiento para importar este archivo de copia de seguridad.</string>
+    <string name="approve_permission">No se puede importar este archivo de copia de seguridad porque se ha denegado el permiso de almacenamiento. ¿Desea aprobarlo en la configuración de la aplicación?</string>
+    <string name="ok">OKAY</string>
 
     <!-- ===================== backup menu ======================== -->
     <string name="backups">Copias de seguridad</string>

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -274,6 +274,10 @@
     <string name="dialog_import_positive">Importer</string>
     <string name="dialog_import_text">Remplacer toutes les données existantes</string>
     <string name="dialog_export_working">Exportation de vos reçus…</string>
+    <string name="storage_permission_required">Permis de stockage requis</string>
+    <string name="permission_must_be_granted">Une autorisation de stockage doit être accordée pour importer ce fichier de sauvegarde.</string>
+    <string name="approve_permission">L\'importation de ce fichier de sauvegarde est impossible car l\'autorisation de stockage a été refusée. Voulez-vous l\'approuver dans les paramètres de l\'application?</string>
+    <string name="ok">D\'accord</string>
 
     <!-- ===================== backup menu ======================== -->
     <string name="backups">Sauvegardes</string>

--- a/app/src/main/res/values-it/strings.xml
+++ b/app/src/main/res/values-it/strings.xml
@@ -287,6 +287,10 @@
     <string name="dialog_import_positive">Importa</string>
     <string name="dialog_import_text">Sovrascrivere tutti i dati esistenti</string>
     <string name="dialog_export_working">Ricevute in esportaziones&#8230;</string>
+    <string name="storage_permission_required">È richiesta l\'autorizzazione allo stoccaggio</string>
+    <string name="permission_must_be_granted">L\'autorizzazione di archiviazione deve essere concessa per importare questo file di backup.</string>
+    <string name="approve_permission">L\'importazione di questo file di backup non può essere eseguita perché l\'autorizzazione di archiviazione è stata negata. Desideri approvarlo nelle impostazioni dell\'app?</string>
+    <string name="ok">OK</string>
 
     <!-- ===================== backup menu ======================== -->
     <string name="backups">Backups</string>

--- a/app/src/main/res/values-iw/strings.xml
+++ b/app/src/main/res/values-iw/strings.xml
@@ -290,6 +290,10 @@
     <string name="dialog_import_positive">ייבוא</string>
     <string name="dialog_import_text">דריסת כל המידע הקיים</string>
     <string name="dialog_export_working">ייצוא הקבלות שלך&#8230;</string>
+    <string name="storage_permission_required">נדרשת הרשאת אחסון</string>
+    <string name="permission_must_be_granted">יש להעניק הרשאת אחסון לייבוא ​​קובץ גיבוי זה.</string>
+    <string name="approve_permission">ייבוא ​​קובץ גיבוי זה לא יכול להיעשות מכיוון שהרשאת האחסון נדחתה. האם תרצה לאשר זאת בהגדרות האפליקציה?</string>
+    <string name="ok">בסדר</string>
 
     <!-- ==================== DIALOG_ABOUT ====================== -->
 

--- a/app/src/main/res/values-pt/strings.xml
+++ b/app/src/main/res/values-pt/strings.xml
@@ -274,6 +274,10 @@
     <string name="dialog_import_positive">Importar</string>
     <string name="dialog_import_text">Substituir todos os dados existentes</string>
     <string name="dialog_export_working">Exportando seus recibos…</string>
+    <string name="storage_permission_required">Permissão de armazenamento necessária</string>
+    <string name="permission_must_be_granted">A permissão de armazenamento deve ser concedida para importar este arquivo de backup.</string>
+    <string name="approve_permission">A importação deste arquivo de backup não pode ser feita porque a permissão de armazenamento foi negada. Deseja aprová-lo nas configurações do aplicativo?</string>
+    <string name="ok">Está bem</string>
 
     <!-- ===================== backup menu ======================== -->
     <string name="backups">Backups</string>

--- a/app/src/main/res/values-ru/strings.xml
+++ b/app/src/main/res/values-ru/strings.xml
@@ -276,6 +276,10 @@
     <string name="dialog_import_positive">Импорт</string>
     <string name="dialog_import_text">Перезаписать все существующие данные</string>
     <string name="dialog_export_working">Экспорт ваших чеков…</string>
+    <string name="storage_permission_required">Требуется разрешение на хранение</string>
+    <string name="permission_must_be_granted">Для импорта этого файла резервной копии необходимо предоставить разрешение на хранение.</string>
+    <string name="approve_permission">Невозможно импортировать этот файл резервной копии, поскольку в разрешении на хранение было отказано. Хотите утвердить его в настройках приложения?</string>
+    <string name="ok">Хорошо</string>
 
     <!-- ===================== backup menu ======================== -->
     <string name="backups">Резервные копии</string>

--- a/app/src/main/res/values-uk/strings.xml
+++ b/app/src/main/res/values-uk/strings.xml
@@ -276,6 +276,10 @@
     <string name="dialog_import_positive">Імпорт</string>
     <string name="dialog_import_text">Перезаписати всі існуючі дані</string>
     <string name="dialog_export_working">Експорт ваших чеків…</string>
+    <string name="storage_permission_required">Необхідний дозвіл на зберігання</string>
+    <string name="permission_must_be_granted">Для імпорту цього резервного файлу повинен бути наданий дозвіл на зберігання.</string>
+    <string name="approve_permission">Імпортувати цей файл резервного копіювання неможливо, оскільки в дозволі на зберігання відмовлено. Хочете затвердити це в налаштуваннях додатка?</string>
+    <string name="ok">гаразд</string>
 
     <!-- ===================== backup menu ======================== -->
     <string name="backups">Резервні копії</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -286,6 +286,10 @@
     <string name="dialog_import_positive">Import</string>
     <string name="dialog_import_text">Overwrite All Existing Data</string>
     <string name="dialog_export_working">Exporting your receipts&#8230;</string>
+    <string name="storage_permission_required">Storage Permission Required</string>
+    <string name="permission_must_be_granted">Storage permission must be granted to import this backup file.</string>
+    <string name="approve_permission">Importing this backup file cannot be done because the storage permission has been denied. Would you like to approve it in the app settings?</string>
+    <string name="ok">OK</string>
 
     <!-- ===================== backup menu ======================== -->
     <string name="backups">Backups</string>


### PR DESCRIPTION
* adding logic to handle storage permission request

* removing unnecessary cast warning

* updating where and when the permission logic runs

* moving permission messages to strings and adding translations

* fixing italian string value

* removing warning

* adding application/x-zip mime type

* moving permission requested alerts to SmartReceiptsActivity

* updating implementation to use presenter

* updating error method to handle permission denied errors gracefully

* adding permission dialog fragment class

* boxing alert dialogs into one dialog fragment

* moving logic from activity to dialog fragment

* updating method tag