### PR TITLE
Release 4.20.2 dupe (#198)

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -27,6 +27,7 @@ jobs:
              printf "\n"
              echo "-- Pushing To Github --"
              printf "\n"
+             git pull https://${GITHUB_API_TOKEN}@github.com/wbaumann/SmartReceiptsLibrary.git ${CIRCLE_BRANCH}
              git config credential.helper 'cache --timeout=120'
              git config user.email ${GITHUB_EMAIL}
              git config user.name ${GITHUB_USERNAME}

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -1,6 +1,6 @@
 plugins {
     id("com.android.application")
-    id("com.github.triplet.play") version "2.4.1"
+    id("com.github.triplet.play") version "2.6.2"
     id("org.jlleitschuh.gradle.ktlint")
 }
 
@@ -22,8 +22,8 @@ android {
     defaultConfig {
         minSdkVersion rootProject.ext.minSdkVersion
         targetSdkVersion rootProject.ext.targetSdkVersion
-        versionCode 1100
-        versionName "4.22.0.1100"
+        versionCode 2201
+        versionName "4.20.2.2201"
         multiDexEnabled true
         vectorDrawables.useSupportLibrary = true
 

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-5.6.2-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-6.0.1-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/gradlew
+++ b/gradlew
@@ -7,7 +7,7 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#      http://www.apache.org/licenses/LICENSE-2.0
+#      https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,
@@ -125,8 +125,8 @@ if $darwin; then
     GRADLE_OPTS="$GRADLE_OPTS \"-Xdock:name=$APP_NAME\" \"-Xdock:icon=$APP_HOME/media/gradle.icns\""
 fi
 
-# For Cygwin, switch paths to Windows format before running java
-if $cygwin ; then
+# For Cygwin or MSYS, switch paths to Windows format before running java
+if [ "$cygwin" = "true" -o "$msys" = "true" ] ; then
     APP_HOME=`cygpath --path --mixed "$APP_HOME"`
     CLASSPATH=`cygpath --path --mixed "$CLASSPATH"`
     JAVACMD=`cygpath --unix "$JAVACMD"`

--- a/gradlew.bat
+++ b/gradlew.bat
@@ -5,7 +5,7 @@
 @rem you may not use this file except in compliance with the License.
 @rem You may obtain a copy of the License at
 @rem
-@rem      http://www.apache.org/licenses/LICENSE-2.0
+@rem      https://www.apache.org/licenses/LICENSE-2.0
 @rem
 @rem Unless required by applicable law or agreed to in writing, software
 @rem distributed under the License is distributed on an "AS IS" BASIS,


### PR DESCRIPTION
* Version bump

* Bumping Project Version [ci skip]

* Admob id update (#165)

* adding dist that has jdk8

* trying openjdk8 versus oraclejdk8

* reverting back to oracle and trying trusty distribution channel

* test commit - removing unused import

* updating google admob library

* updating google play services library

* updating kotlin version

* updating spelling

* removing reference to deleted service class

* adding admob ad id

* updating to include new ad string

* adding placeholder that is only in secrets file

* moving admob_ad_id reference from main to free manifest

* reverting change to fix AS conflict

* re-adding placeholder admob_ad_id

* Bumping Project Version [ci skip]

* Circle ci fix (#168)

* deleting preconditions file, conflicting with library

* updating gradle wrapper version

* updating gpp version

* adding command to clear gradle cache before publishing

* Bumping Project Version [ci skip]

* Version bump

* Bumping Project Version [ci skip]

* Pdf render fixes (#169)

* removing close as it closes before pdf generation is finished

* updating to not bump minor version, just versionCode

* Version reset

* Bumping Project Version [ci skip]

* Bugfixes (#171)

* Updated ads.xml

* Fixed bug: ImageImportProcessor imported all files as JPEG, added PNG support

* Fixed bug: incorrectly saved images after crop couldn't be printed to PDF

* Bumping Project Version [ci skip]

* Added code that fixes consequences of a bug with cropped images (#173)

* Bumping Project Version [ci skip]

* Google drive api limit reached (#172)

* adding drive_key string file

* setting the key for every api call

* updating google api dependencies

* adding drive_key string values to secrets

* moving file from plusFlavor to main

* updating secrets for moved file

* Bumping Project Version [ci skip]

* Merge pull request #177 from HeinousGames/GoogleDriveAPITokenAdjustment

Google drive api token adjustment

* Bumping Project Version [ci skip]

* updating circle docker image

* Bumping Project Version [ci skip]

* Google drive api token adjustment (#180)

* reverting token additions

* adding key class for drive api functionality

* updating google api library version

* Bumping Project Version [ci skip]

* Image crop fix (#183)

* removing png compression options

* removing warnings

* Bumping Project Version [ci skip]

* Pdf footer temp fix (#188)

* Version bump

* Bumping Project Version [ci skip]

* Admob id update (#165)

* adding dist that has jdk8

* trying openjdk8 versus oraclejdk8

* reverting back to oracle and trying trusty distribution channel

* test commit - removing unused import

* updating google admob library

* updating google play services library

* updating kotlin version

* updating spelling

* removing reference to deleted service class

* adding admob ad id

* updating to include new ad string

* adding placeholder that is only in secrets file

* moving admob_ad_id reference from main to free manifest

* reverting change to fix AS conflict

* re-adding placeholder admob_ad_id

* Bumping Project Version [ci skip]

* Circle ci fix (#168)

* deleting preconditions file, conflicting with library

* updating gradle wrapper version

* updating gpp version

* adding command to clear gradle cache before publishing

* Bumping Project Version [ci skip]

* Version bump

* Bumping Project Version [ci skip]

* Pdf render fixes (#169)

* removing close as it closes before pdf generation is finished

* updating to not bump minor version, just versionCode

* Version reset

* Bumping Project Version [ci skip]

* Bugfixes (#171)

* Updated ads.xml

* Fixed bug: ImageImportProcessor imported all files as JPEG, added PNG support

* Fixed bug: incorrectly saved images after crop couldn't be printed to PDF

* Bumping Project Version [ci skip]

* Added code that fixes consequences of a bug with cropped images (#173)

* Bumping Project Version [ci skip]

* Google drive api limit reached (#172)

* adding drive_key string file

* setting the key for every api call

* updating google api dependencies

* adding drive_key string values to secrets

* moving file from plusFlavor to main

* updating secrets for moved file

* Bumping Project Version [ci skip]

* Merge pull request #177 from HeinousGames/GoogleDriveAPITokenAdjustment

Google drive api token adjustment

* Bumping Project Version [ci skip]

* updating circle docker image

* Bumping Project Version [ci skip]

* Google drive api token adjustment (#180)

* reverting token additions

* adding key class for drive api functionality

* updating google api library version

* Bumping Project Version [ci skip]

* Image crop fix (#183)

* removing png compression options

* removing warnings

* Bumping Project Version [ci skip]

* not allowing empty footer strings

* Ocr fix (#194)

* Version bump

* Bumping Project Version [ci skip]

* Admob id update (#165)

* adding dist that has jdk8

* trying openjdk8 versus oraclejdk8

* reverting back to oracle and trying trusty distribution channel

* test commit - removing unused import

* updating google admob library

* updating google play services library

* updating kotlin version

* updating spelling

* removing reference to deleted service class

* adding admob ad id

* updating to include new ad string

* adding placeholder that is only in secrets file

* moving admob_ad_id reference from main to free manifest

* reverting change to fix AS conflict

* re-adding placeholder admob_ad_id

* Bumping Project Version [ci skip]

* Circle ci fix (#168)

* deleting preconditions file, conflicting with library

* updating gradle wrapper version

* updating gpp version

* adding command to clear gradle cache before publishing

* Bumping Project Version [ci skip]

* Version bump

* Bumping Project Version [ci skip]

* Pdf render fixes (#169)

* removing close as it closes before pdf generation is finished

* updating to not bump minor version, just versionCode

* Version reset

* Bumping Project Version [ci skip]

* Bugfixes (#171)

* Updated ads.xml

* Fixed bug: ImageImportProcessor imported all files as JPEG, added PNG support

* Fixed bug: incorrectly saved images after crop couldn't be printed to PDF

* Bumping Project Version [ci skip]

* Added code that fixes consequences of a bug with cropped images (#173)

* Bumping Project Version [ci skip]

* Google drive api limit reached (#172)

* adding drive_key string file

* setting the key for every api call

* updating google api dependencies

* adding drive_key string values to secrets

* moving file from plusFlavor to main

* updating secrets for moved file

* Bumping Project Version [ci skip]

* Merge pull request #177 from HeinousGames/GoogleDriveAPITokenAdjustment

Google drive api token adjustment

* Bumping Project Version [ci skip]

* updating circle docker image

* Bumping Project Version [ci skip]

* Google drive api token adjustment (#180)

* reverting token additions

* adding key class for drive api functionality

* updating google api library version

* Bumping Project Version [ci skip]

* Image crop fix (#183)

* removing png compression options

* removing warnings

* Bumping Project Version [ci skip]

* disabling proguard for amazon/google dependency conflict

Co-authored-by: Will Baumann <will.r.baumann@gmail.com>
Co-authored-by: JuliaSoboleva <julia.soboleva26@gmail.com>

* Ocr fix (#195)

* Version bump

* Bumping Project Version [ci skip]

* Admob id update (#165)

* adding dist that has jdk8

* trying openjdk8 versus oraclejdk8

* reverting back to oracle and trying trusty distribution channel

* test commit - removing unused import

* updating google admob library

* updating google play services library

* updating kotlin version

* updating spelling

* removing reference to deleted service class

* adding admob ad id

* updating to include new ad string

* adding placeholder that is only in secrets file

* moving admob_ad_id reference from main to free manifest

* reverting change to fix AS conflict

* re-adding placeholder admob_ad_id

* Bumping Project Version [ci skip]

* Circle ci fix (#168)

* deleting preconditions file, conflicting with library

* updating gradle wrapper version

* updating gpp version

* adding command to clear gradle cache before publishing

* Bumping Project Version [ci skip]

* Version bump

* Bumping Project Version [ci skip]

* Pdf render fixes (#169)

* removing close as it closes before pdf generation is finished

* updating to not bump minor version, just versionCode

* Version reset

* Bumping Project Version [ci skip]

* Bugfixes (#171)

* Updated ads.xml

* Fixed bug: ImageImportProcessor imported all files as JPEG, added PNG support

* Fixed bug: incorrectly saved images after crop couldn't be printed to PDF

* Bumping Project Version [ci skip]

* Added code that fixes consequences of a bug with cropped images (#173)

* Bumping Project Version [ci skip]

* Google drive api limit reached (#172)

* adding drive_key string file

* setting the key for every api call

* updating google api dependencies

* adding drive_key string values to secrets

* moving file from plusFlavor to main

* updating secrets for moved file

* Bumping Project Version [ci skip]

* Merge pull request #177 from HeinousGames/GoogleDriveAPITokenAdjustment

Google drive api token adjustment

* Bumping Project Version [ci skip]

* updating circle docker image

* Bumping Project Version [ci skip]

* Google drive api token adjustment (#180)

* reverting token additions

* adding key class for drive api functionality

* updating google api library version

* Bumping Project Version [ci skip]

* Image crop fix (#183)

* removing png compression options

* removing warnings

* Bumping Project Version [ci skip]

* disabling proguard for amazon/google dependency conflict

* reverting to allow logging in to ocr profile

* reverting to use proguard

* updating google, amazon, and logging libraries

* adding google client/services proguard rules

* adding aws proguard rules

* updating aws library

Co-authored-by: Will Baumann <will.r.baumann@gmail.com>
Co-authored-by: JuliaSoboleva <julia.soboleva26@gmail.com>

* Ad updates (#196)

* updating dependencies

* removing spelling warnings

* Bumping Project Version [ci skip]

* updating gradle, gpp, and circleci config

Co-authored-by: Will Baumann <will.r.baumann@gmail.com>
Co-authored-by: JuliaSoboleva <julia.soboleva26@gmail.com>