### PR TITLE
Google min api (#239)

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -46,6 +46,11 @@ android {
             keyPassword System.getenv("KEY_PASSWORD")
         }
     }
+
+    buildFeatures {
+        viewBinding true
+    }
+
     buildTypes {
         debug {
             minifyEnabled false
@@ -126,10 +131,6 @@ android {
             }
         }
         execution 'ANDROIDX_TEST_ORCHESTRATOR'
-    }
-
-    viewBinding {
-        enabled = true
     }
 
     dependencies {

--- a/app/src/main/java/co/smartreceipts/android/autocomplete/AutoCompleteArrayAdapter.kt
+++ b/app/src/main/java/co/smartreceipts/android/autocomplete/AutoCompleteArrayAdapter.kt
@@ -10,7 +10,6 @@ import android.view.View
 import android.view.ViewGroup
 import android.widget.ImageView
 
-
 /**
  * Modifies the core [ArrayAdapter] contract to address a bug that is specific to auto-completion
  */

--- a/app/src/main/java/co/smartreceipts/android/distance/editor/DistanceAutoCompletePresenter.kt
+++ b/app/src/main/java/co/smartreceipts/android/distance/editor/DistanceAutoCompletePresenter.kt
@@ -20,10 +20,10 @@ class DistanceAutoCompletePresenter @Inject constructor(
                 .flatMap { t ->
                     positionToRemoveOrAdd = t.position
                     when (t.type) {
-                        DistanceAutoCompleteField.Location -> interactor.updateDistance(t.item.firstItem, DistanceBuilderFactory(t.item.firstItem)
+                        DistanceAutoCompleteField.Location -> interactor.updateDistance(t.item!!.firstItem, DistanceBuilderFactory(t.item.firstItem)
                                 .setLocationHiddenFromAutoComplete(true)
                                 .build())
-                        DistanceAutoCompleteField.Comment -> interactor.updateDistance(t.item.firstItem, DistanceBuilderFactory(t.item.firstItem)
+                        DistanceAutoCompleteField.Comment -> interactor.updateDistance(t.item!!.firstItem, DistanceBuilderFactory(t.item.firstItem)
                                 .setCommentHiddenFromAutoComplete(true)
                                 .build())
                         else -> throw UnsupportedOperationException("Unknown type: " + t.type)
@@ -39,10 +39,10 @@ class DistanceAutoCompletePresenter @Inject constructor(
         compositeDisposable.add(view.unHideAutoCompleteVisibilityClick
                 .flatMap { t ->
                     when (t.type) {
-                        DistanceAutoCompleteField.Location -> interactor.updateDistance(t.item.firstItem, DistanceBuilderFactory(t.item.firstItem)
+                        DistanceAutoCompleteField.Location -> interactor.updateDistance(t.item!!.firstItem, DistanceBuilderFactory(t.item.firstItem)
                                 .setLocationHiddenFromAutoComplete(false)
                                 .build())
-                        DistanceAutoCompleteField.Comment -> interactor.updateDistance(t.item.firstItem, DistanceBuilderFactory(t.item.firstItem)
+                        DistanceAutoCompleteField.Comment -> interactor.updateDistance(t.item!!.firstItem, DistanceBuilderFactory(t.item.firstItem)
                                 .setCommentHiddenFromAutoComplete(false)
                                 .build())
                         else -> throw UnsupportedOperationException("Unknown type: " + t.type)

--- a/app/src/main/java/co/smartreceipts/android/distance/editor/DistanceCreateEditFragment.kt
+++ b/app/src/main/java/co/smartreceipts/android/distance/editor/DistanceCreateEditFragment.kt
@@ -49,6 +49,7 @@ import javax.inject.Inject
 
 class DistanceCreateEditFragment : WBFragment(), DistanceCreateEditView, View.OnFocusChangeListener,
         PaymentMethodsView {
+
     @Inject
     lateinit var presenter: DistanceCreateEditPresenter
 
@@ -89,7 +90,7 @@ class DistanceCreateEditFragment : WBFragment(), DistanceCreateEditView, View.On
 
     private lateinit var paymentMethodsAdapter: FooterButtonArrayAdapter<PaymentMethod>
 
-    private lateinit var itemToRemoveOrReAdd: AutoCompleteResult<Distance>
+    private var itemToRemoveOrReAdd: AutoCompleteResult<Distance>? = null
 
     private var _binding: UpdateDistanceBinding? = null
     private val binding get() = _binding!!
@@ -437,7 +438,7 @@ class DistanceCreateEditFragment : WBFragment(), DistanceCreateEditView, View.On
             resultsAdapter.notifyDataSetChanged()
             val view = activity!!.findViewById<ConstraintLayout>(R.id.update_distance_layout)
             snackbar = Snackbar.make(view, getString(
-                    R.string.item_removed_from_auto_complete, itemToRemoveOrReAdd.displayName), Snackbar.LENGTH_LONG)
+                    R.string.item_removed_from_auto_complete, itemToRemoveOrReAdd!!.displayName), Snackbar.LENGTH_LONG)
             snackbar.setAction(R.string.undo) {
                 if (text_distance_location.hasFocus()) {
                     _unHideAutoCompleteVisibilityClicks.onNext(

--- a/app/src/main/java/co/smartreceipts/android/fragments/ReceiptImageFragment.kt
+++ b/app/src/main/java/co/smartreceipts/android/fragments/ReceiptImageFragment.kt
@@ -74,11 +74,11 @@ class ReceiptImageFragment : WBFragment() {
     @Inject
     lateinit var picasso: Lazy<Picasso>
 
-    private lateinit var receipt: Receipt
     private lateinit var imageUpdatedListener: ImageUpdatedListener
     private lateinit var compositeDisposable: CompositeDisposable
 
     private var imageUri: Uri? = null
+    private var receipt: Receipt? = null
 
     override fun onAttach(context: Context?) {
         AndroidSupportInjection.inject(this)
@@ -103,12 +103,12 @@ class ReceiptImageFragment : WBFragment() {
         rootView.button_edit_photo.setOnClickListener { view ->
             analytics.record(Events.Receipts.ReceiptImageViewEditPhoto)
             imageCroppingPreferenceStorage.setCroppingScreenWasShown(true)
-            navigationHandler.navigateToCropActivity(this, receipt.file!!, RequestCodes.EDIT_IMAGE_CROP)
+            navigationHandler.navigateToCropActivity(this, receipt!!.file!!, RequestCodes.EDIT_IMAGE_CROP)
         }
 
         rootView.button_retake_photo.setOnClickListener { view ->
             analytics.record(Events.Receipts.ReceiptImageViewRetakePhoto)
-            imageUri = CameraInteractionController(this@ReceiptImageFragment).retakePhoto(receipt)
+            imageUri = CameraInteractionController(this@ReceiptImageFragment).retakePhoto(receipt!!)
         }
 
         return rootView
@@ -140,7 +140,7 @@ class ReceiptImageFragment : WBFragment() {
                     Logger.error(this, "An error occurred while cropping the image")
                 }
                 else -> {
-                    picasso.get().invalidate(receipt.file!!)
+                    picasso.get().invalidate(receipt!!.file!!)
                     loadImage()
                 }
             }
@@ -165,7 +165,7 @@ class ReceiptImageFragment : WBFragment() {
                         receipt_image_progress.visibility = View.VISIBLE
                         activityFileResultImporter.importFile(
                             locatorResponse.requestCode,
-                            locatorResponse.resultCode, locatorResponse.uri!!, receipt.trip
+                            locatorResponse.resultCode, locatorResponse.uri!!, receipt!!.trip
                         )
                     }
                 }
@@ -176,8 +176,8 @@ class ReceiptImageFragment : WBFragment() {
                 when {
                     throwable.isPresent -> Toast.makeText(activity, getFlexString(R.string.IMG_SAVE_ERROR), Toast.LENGTH_SHORT).show()
                     else -> {
-                        val retakeReceipt = ReceiptBuilderFactory(receipt).setFile(file).build()
-                        receiptTableController.update(receipt, retakeReceipt, DatabaseOperationMetadata())
+                        val retakeReceipt = ReceiptBuilderFactory(receipt!!).setFile(file).build()
+                        receiptTableController.update(receipt!!, retakeReceipt, DatabaseOperationMetadata())
                     }
                 }
                 receipt_image_progress.visibility = View.GONE
@@ -192,7 +192,7 @@ class ReceiptImageFragment : WBFragment() {
         actionBar?.apply {
             setHomeButtonEnabled(true)
             setDisplayHomeAsUpEnabled(true)
-            title = receipt.name
+            title = receipt!!.name
         }
         receiptTableController.subscribe(imageUpdatedListener)
 
@@ -228,7 +228,7 @@ class ReceiptImageFragment : WBFragment() {
                 true
             }
             R.id.action_share -> {
-                receipt.file?.let {
+                receipt!!.file?.let {
                     val sendIntent = IntentUtils.getSendIntent(requireActivity(), it)
                     startActivity(Intent.createChooser(sendIntent, resources.getString(R.string.send_email)))
                 }
@@ -241,8 +241,8 @@ class ReceiptImageFragment : WBFragment() {
 
     private fun loadImage() {
 
-        if (receipt.hasImage()) {
-            receipt.file?.let {
+        if (receipt!!.hasImage()) {
+            receipt!!.file?.let {
                 receipt_image_progress.visibility = View.VISIBLE
 
                 picasso.get().load(it).memoryPolicy(MemoryPolicy.NO_CACHE, MemoryPolicy.NO_STORE).fit().centerInside()

--- a/app/src/main/java/co/smartreceipts/android/model/AutoCompleteUpdateEvent.kt
+++ b/app/src/main/java/co/smartreceipts/android/model/AutoCompleteUpdateEvent.kt
@@ -4,7 +4,7 @@ import co.smartreceipts.android.autocomplete.AutoCompleteField
 import co.smartreceipts.android.autocomplete.AutoCompleteResult
 
 data class AutoCompleteUpdateEvent<Type>(
-    val item: AutoCompleteResult<Type>,
+    val item: AutoCompleteResult<Type>?,
     val type: AutoCompleteField,
     val position: Int
 )

--- a/app/src/main/java/co/smartreceipts/android/receipts/editor/paymentmethods/PaymentMethodsPresenter.kt
+++ b/app/src/main/java/co/smartreceipts/android/receipts/editor/paymentmethods/PaymentMethodsPresenter.kt
@@ -38,9 +38,11 @@ class PaymentMethodsPresenter @Inject constructor(view: PaymentMethodsView,
                 .subscribeOn(ioScheduler)
                 .observeOn(mainScheduler)
                 .subscribe { t: MutableList<PaymentMethod>? ->
-                    val paymentMethods = ArrayList(t)
-                    paymentMethods.add(PaymentMethod.NONE)
-                    view.displayPaymentMethods(paymentMethods)
+                    if (t != null) {
+                        val paymentMethods = ArrayList(t.toMutableList())
+                        paymentMethods.add(PaymentMethod.NONE)
+                        view.displayPaymentMethods(paymentMethods)
+                    }
                 })
     }
 

--- a/app/src/test/java/co/smartreceipts/android/utils/ParcelableTestUtil.kt
+++ b/app/src/test/java/co/smartreceipts/android/utils/ParcelableTestUtil.kt
@@ -31,8 +31,8 @@ fun marshall(bundle: Bundle): ByteArray =
 inline fun <reified R : Parcelable> unmarshallParcelable(bytes: ByteArray): R = unmarshall(bytes)
     .readBundle()
     .run {
-        classLoader = R::class.java.classLoader
-        getParcelable(R::class.java.name)
+        this!!.classLoader = R::class.java.classLoader
+        getParcelable(R::class.java.name)!!
     }
 
 @VisibleForTesting

--- a/app/src/test/java/co/smartreceipts/android/workers/reports/ReportResourcesManagerTest.kt
+++ b/app/src/test/java/co/smartreceipts/android/workers/reports/ReportResourcesManagerTest.kt
@@ -108,6 +108,6 @@ class ReportResourcesManagerTest {
     }
 
     private fun setDefaultLocaleForConfiguration(locale: Locale) {
-        configuration.locales = LocaleList(locale)
+        configuration.setLocales(LocaleList(locale))
     }
 }

--- a/build.gradle
+++ b/build.gradle
@@ -33,7 +33,7 @@ allprojects {
 
 ext {
     minSdkVersion = 21
-    targetSdkVersion = 28
-    compileSdkVersion = 28
-    buildToolsVersion = "28.0.3"
+    targetSdkVersion = 29
+    compileSdkVersion = 29
+    buildToolsVersion = "29.0.3"
 }


### PR DESCRIPTION
* updating logic to apply to items where fields are already filled

* removing editor from presenter constructor

* updating tests to check same values whether editing or not

* updating logic to apply to items where fields are already filled

* removing editor from presenter constructor

* updating tests to check same values whether editing or not

* updating api numbers

* updating view binding config

* updating distance type references

* enforcing receipt non-null

* updating payment method arraylist

* code cleanliness

* locales removed in api 29

* needs to be reassured not null